### PR TITLE
Fix limited number of devices returned

### DIFF
--- a/AuvikAPI/Resources/Device.ps1
+++ b/AuvikAPI/Resources/Device.ps1
@@ -1,13 +1,16 @@
 function Get-AuvikDevicesInfo {
-    [CmdletBinding(DefaultParameterSetName = 'index')]
+    [CmdletBinding(DefaultParameterSetName = 'index-after')]
     Param (
-        [Parameter(ParameterSetName = 'show')]
+        [Parameter(ParameterSetName = 'show-after')]
+        [Parameter(ParameterSetName = 'show-before')]
         [String[]]$Id,
 
-        [Parameter(ParameterSetName = 'index')]
+        [Parameter(ParameterSetName = 'index-after')]
+        [Parameter(ParameterSetName = 'index-before')]
         [String[]]$Networks = '',
 
-        [Parameter(ParameterSetName = 'index')]
+        [Parameter(ParameterSetName = 'index-after')]
+        [Parameter(ParameterSetName = 'index-before')]
         [ValidateSet('unknown', 'switch', 'l3Switch', 'router', `
             'accessPoint', 'firewall', 'workstation', 'server', 'storage', `
             'printer', 'copier', 'hypervisor', 'multimedia', 'phone', `
@@ -21,29 +24,42 @@ function Get-AuvikDevicesInfo {
             'ipmi', 'thinAccessPoint', 'thinClient')]
         [String]$DeviceType = '',
 
-        [Parameter(ParameterSetName = 'index')]
+        [Parameter(ParameterSetName = 'index-after')]
+        [Parameter(ParameterSetName = 'index-before')]
         [String]$MakeModel = '',
 
-        [Parameter(ParameterSetName = 'index')]
+        [Parameter(ParameterSetName = 'index-after')]
+        [Parameter(ParameterSetName = 'index-before')]
         [String]$VendorName = '',
 
-        [Parameter(ParameterSetName = 'index')]
+        [Parameter(ParameterSetName = 'index-after')]
+        [Parameter(ParameterSetName = 'index-before')]
         [ValidateSet('online', 'offline', 'unreachable', 'testing', `
             'unknown', 'dormant', 'notPresent', 'lowerLayerDown')]
         [String]$Status = '',
 
-        [Parameter(ParameterSetName = 'index')]
+        [Parameter(ParameterSetName = 'index-after')]
+        [Parameter(ParameterSetName = 'index-before')]
         [datetime]$ModifiedAfter,
 
-        [Parameter(ParameterSetName = 'index')]
+        [Parameter(ParameterSetName = 'index-after')]
+        [Parameter(ParameterSetName = 'index-before')]
         [String[]]$Tenants = '',
 
-        [Parameter(ParameterSetName = 'show')]
-        [Parameter(ParameterSetName = 'index')]
         [ValidateSet('discoveryStatus', 'components', 'connectedDevices', `
             'configurations', 'manageStatus', 'interfaces')]
-        [String[]]$IncludeDetailFields = ''
+        [String[]]$IncludeDetailFields = '',
 
+        [Parameter(ParameterSetName = 'index-after')]
+        [Parameter(ParameterSetName = 'show-after')]
+        [String]$After,
+
+        [Parameter(ParameterSetName = 'index-before')]
+        [Parameter(ParameterSetName = 'show-before')]
+        [String]$Before,
+
+        [ValidateRange(1, 1000)]
+        [Int] $Limit
     )
 
 Begin {

--- a/AuvikAPI/Resources/Device.ps1
+++ b/AuvikAPI/Resources/Device.ps1
@@ -1,10 +1,6 @@
 function Get-AuvikDevicesInfo {
     [CmdletBinding(DefaultParameterSetName = 'index-after')]
     Param (
-        [Parameter(ParameterSetName = 'show-after')]
-        [Parameter(ParameterSetName = 'show-before')]
-        [String[]]$Id,
-
         [Parameter(ParameterSetName = 'index-after')]
         [Parameter(ParameterSetName = 'index-before')]
         [String[]]$Networks = '',
@@ -45,6 +41,10 @@ function Get-AuvikDevicesInfo {
         [Parameter(ParameterSetName = 'index-after')]
         [Parameter(ParameterSetName = 'index-before')]
         [String[]]$Tenants = '',
+
+        [Parameter(ParameterSetName = 'show-after')]
+        [Parameter(ParameterSetName = 'show-before')]
+        [String[]]$Id,
 
         [ValidateSet('discoveryStatus', 'components', 'connectedDevices', `
             'configurations', 'manageStatus', 'interfaces')]

--- a/AuvikAPI/Resources/Device.ps1
+++ b/AuvikAPI/Resources/Device.ps1
@@ -50,14 +50,20 @@ function Get-AuvikDevicesInfo {
             'configurations', 'manageStatus', 'interfaces')]
         [String[]]$IncludeDetailFields = '',
 
+        # The ID of a device after which records will be returned as a page.
+        # Use the Limit parameter to control the size of the page returned.
         [Parameter(ParameterSetName = 'index-after')]
         [Parameter(ParameterSetName = 'show-after')]
         [String]$After,
 
+        # The ID of a device before which records will be returned as a page.
+        # Use the Limit parameter to control the size of the page returned.
         [Parameter(ParameterSetName = 'index-before')]
         [Parameter(ParameterSetName = 'show-before')]
         [String]$Before,
 
+        # Controls how many devices are returned. If unspecified, the maximum number of devices returned is 100.
+        # Can be supplied with the After or Before parameters, or by itself to generate an initial page of results.
         [ValidateRange(1, 1000)]
         [Int] $Limit
     )
@@ -100,6 +106,20 @@ Process {
     }
     Else {
         #Parameter set "Show" is selected
+    }
+
+    If ($After) {
+        $qparams += @{'page[after]' = $After}
+        If ($Limit) {
+            $qparams += @{'page[first]' = $Limit.ToString()}
+        }
+    } ElseIf ($Before) {
+        $qparams += @{'page[before]' = $Before}
+        If ($Limit) {
+            $qparams += @{'page[last]' = $Limit.ToString()}
+        }
+    } ElseIf ($Limit) {
+        $qparams += @{'page[first]' = $Limit.ToString()}
     }
 
     ForEach ($deviceId IN $Id) {

--- a/AuvikAPI/Resources/Device.ps1
+++ b/AuvikAPI/Resources/Device.ps1
@@ -3,7 +3,7 @@ function Get-AuvikDevicesInfo {
     Param (
         [Parameter(ParameterSetName = 'show')]
         [String[]]$Id,
- 
+
         [Parameter(ParameterSetName = 'index')]
         [String[]]$Networks = '',
 
@@ -100,8 +100,8 @@ Process {
             $rest_output = try {
                 $Null = $AuvikAPI_Headers.Add("Authorization", "Basic $x_api_authorization")
                 Invoke-RestMethod -method 'GET' -uri ($Auvik_Base_URI + $resource_uri) -Headers $AuvikAPI_Headers -Body $qparams -ErrorAction SilentlyContinue
-            } catch [System.Net.WebException] { 
-                $_.Exception.Response 
+            } catch [System.Net.WebException] {
+                $_.Exception.Response
             } catch {
                 Write-Error $_
             } finally {
@@ -125,7 +125,7 @@ function Get-AuvikDevicesDetails {
     Param (
         [Parameter(ParameterSetName = 'show')]
         [String[]]$Id,
- 
+
         [Parameter(ParameterSetName = 'index')]
         [ValidateSet('disabled', 'determining', 'notSupported', `
             'notAuthorized', 'authorizing', 'authorized', 'privileged')]
@@ -160,7 +160,7 @@ Begin {
     $x_api_authorization = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($x_api_authorization))
 }
 
-Process {    
+Process {
 
     If ($PSCmdlet.ParameterSetName -eq 'index') {
         $Id = @('')
@@ -205,8 +205,8 @@ Process {
             $rest_output = try {
                 $Null = $AuvikAPI_Headers.Add("Authorization", "Basic $x_api_authorization")
                 Invoke-RestMethod -method 'GET' -uri ($Auvik_Base_URI + $resource_uri) -Headers $AuvikAPI_Headers -Body $qparams -ErrorAction SilentlyContinue
-            } catch [System.Net.WebException] { 
-                $_.Exception.Response 
+            } catch [System.Net.WebException] {
+                $_.Exception.Response
             } catch {
                 Write-Error $_
             } finally {
@@ -229,7 +229,7 @@ function Get-AuvikDevicesExtendedDetails {
     Param (
         [Parameter(ParameterSetName = 'show')]
         [String]$Id,
- 
+
         [Parameter(ParameterSetName = 'index', Mandatory=$True)]
         [ValidateSet('unknown', 'switch', 'l3Switch', 'router', `
             'accessPoint', 'firewall', 'workstation', 'server', 'storage', `
@@ -259,7 +259,7 @@ Begin {
     $x_api_authorization = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($x_api_authorization))
 }
 
-Process {    
+Process {
 
     If ($PSCmdlet.ParameterSetName -eq 'index') {
         $Id = @('')
@@ -291,8 +291,8 @@ Process {
             $rest_output = try {
                 $Null = $AuvikAPI_Headers.Add("Authorization", "Basic $x_api_authorization")
                 Invoke-RestMethod -method 'GET' -uri ($Auvik_Base_URI + $resource_uri) -Headers $AuvikAPI_Headers -Body $qparams -ErrorAction SilentlyContinue
-            } catch [System.Net.WebException] { 
-                $_.Exception.Response 
+            } catch [System.Net.WebException] {
+                $_.Exception.Response
             } catch {
                 Write-Error $_
             } finally {

--- a/AuvikAPI/Resources/Device.ps1
+++ b/AuvikAPI/Resources/Device.ps1
@@ -54,6 +54,7 @@ function Get-AuvikDevicesInfo {
 
         # Controls how many devices are returned. If unspecified, the maximum number of devices returned is 100.
         # Can be supplied with the After or Before parameters, or by itself to generate an initial page of results.
+        [Parameter(ParameterSetName = 'index')]
         [ValidateRange(1, 1000)]
         [Int] $Limit
     )
@@ -198,6 +199,7 @@ function Get-AuvikDevicesDetails {
 
         # Controls how many devices are returned. If unspecified, the maximum number of devices returned is 100.
         # Can be supplied with the After or Before parameters, or by itself to generate an initial page of results.
+        [Parameter(ParameterSetName = 'index')]
         [ValidateRange(1, 1000)]
         [Int] $Limit
     )
@@ -333,9 +335,9 @@ function Get-AuvikDevicesExtendedDetails {
 
         # Controls how many devices are returned. If unspecified, the maximum number of devices returned is 100.
         # Can be supplied with the After or Before parameters, or by itself to generate an initial page of results.
+        [Parameter(ParameterSetName = 'index')]
         [ValidateRange(1, 1000)]
         [Int] $Limit
-
     )
 
 Begin {


### PR DESCRIPTION
Hey @DarrenWhite99, this PR introduces the pagination parameters for the Auvik API.

I ran into an issue with some reports I was building where all of our tenants had exactly 100 devices and their billable device count was a lot lower than expected!

Turns out the API was defaulting to only returning 100 devices per page and I had no control over the page size or moving over to the second page via the functions.

This PR introduces three new parameters on each of the devices functions:

```
        # The cursor ID after which device records will be returned as a page, available in the meta property.
        # Use the Limit parameter to control the size of the page returned.
        [Parameter(ParameterSetName = 'index')]
        [String]$After,

        # The cursor ID before which device records will be returned as a page, available in the meta property.
        # Use the Limit parameter to control the size of the page returned.
        [Parameter(ParameterSetName = 'index')]
        [String]$Before,

        # Controls how many devices are returned. If unspecified, the maximum number of devices returned is 100.
        # Can be supplied with the After or Before parameters, or by itself to generate an initial page of results.
        [Parameter(ParameterSetName = 'index')]
        [ValidateRange(1, 1000)]
        [Int] $Limit
```

`Limit` can be used to bring the page size up or down, but I found that the maximum value accepted by the API was 1000.

The `before` and `after` parameters need a "cursor ID" which is available in the links properties of the returned json object... I've extracted this and added as a note property in the meta attribute for each reference, e.g.:

```powershell
$DevicesPageOne = Get-AuvikDevicesInfo -Tenants $Tenants.id -Limit 100
$DevicesPageTwo = Get-AuvikDevicesInfo -Tenants $Tenants.id -Limit 100 -After $DevicesPageOne.meta.nextCursor
```

Thanks for the module, it's been a great help!